### PR TITLE
util/filemap.py : Minor update to driver mapping table

### DIFF
--- a/util/filemap.py
+++ b/util/filemap.py
@@ -190,8 +190,11 @@ DRIVER_OS_MAP = {
         'win7/x86': ['w7/x86'],
         'win7/amd64': ['2k8R2/amd64', 'w7/amd64'],
 
-        'win8/x86': ['w8/x86', 'w8.1/x86'],
-        'win8/amd64': ['w8/amd64', 'w8.1/amd64', '2k12/amd64', '2k12R2/amd64'],
+        'win8/x86': ['w8/x86'],
+        'win8/amd64': ['w8/amd64', '2k12/amd64'],
+
+        'win8.1/x86': ['w8.1/x86'],
+        'win8.1/amd64': ['w8.1/amd64', '2k12R2/amd64'],
 
         'win10/x86': ['w10/x86'],
         'win10/amd64': ['w10/amd64', '2k16/amd64'],


### PR DESCRIPTION
util/filemap.py : One more tweak to filemap.py following the latest development in

https://bugzilla.redhat.com/show_bug.cgi?id=1325078
(comments 36-38)

NetKVM for Windows 8.1 and 2012 R2 should come from the Win8.1 build (was Win8).