### PR TITLE
filemap: Update NetKVM build paths

### DIFF
--- a/make-driver-dir.py
+++ b/make-driver-dir.py
@@ -191,8 +191,6 @@ def check_remaining_files(input_dir, seenfiles):
         # If you add to this list, be sure it's not a newly introduced
         # driver that you are ignoring! Everything listed here needs
         # be covered by a mapping in DRIVER_OS_MAP
-        ".*/Wnet/x86/balloon.*", ".*/Wnet/x86/blnsvr.*",
-        ".*/Wnet/x86/vioser.*", ".*/Wnet/x86/WdfCoInstaller01009.dll",
     ]
 
     remaining = []

--- a/make-driver-dir.py
+++ b/make-driver-dir.py
@@ -58,13 +58,14 @@ def download_virtio_win_license(outdir):
     return [destfile]
 
 
-def copy_pciserial(input_dir, outdir):
-    destdir = os.path.join(outdir, "qemupciserial")
+def copy_inf_cat_driver(input_dir, outdir, drivername):
+    # Copies a driver consisting of just an .inf and .cat file
+    destdir = os.path.join(outdir, drivername)
     os.mkdir(destdir)
 
     seenfiles = [
-        os.path.join(input_dir, "qemupciserial.inf"),
-        os.path.join(input_dir, "qemupciserial.cat"),
+        os.path.join(input_dir, drivername + ".inf"),
+        os.path.join(input_dir, drivername + ".cat"),
     ]
 
     for f in seenfiles:
@@ -270,7 +271,8 @@ def main():
     seenfiles = []
     seenfiles += copy_virtio_drivers(options.input_dir, outdir)
     seenfiles += download_virtio_win_license(outdir)
-    seenfiles += copy_pciserial(options.input_dir, outdir)
+    seenfiles += copy_inf_cat_driver(options.input_dir, outdir, "qemupciserial")
+    seenfiles += copy_inf_cat_driver(options.input_dir, outdir, "qemufwcfg")
 
     # Verify that there is nothing left over that we missed
     check_remaining_files(options.input_dir, seenfiles)

--- a/util/filemap.py
+++ b/util/filemap.py
@@ -177,8 +177,9 @@ FILELISTS['viostor'] = [
 #        output-dir/2k3/x86
 DRIVER_OS_MAP = {
     'Balloon': {
-        'Wxp/x86': ['xp/x86', '2k3/x86'],
+        'Wxp/x86': ['xp/x86'],
 
+        'Wnet/x86' : ['2k3/x86'],
         'Wnet/amd64': ['2k3/amd64'],
 
         'Wlh/x86': ['2k8/x86'],
@@ -196,8 +197,9 @@ DRIVER_OS_MAP = {
 
 
     'NetKVM': {
-        'Wxp/x86': ['xp/x86', '2k3/x86'],
+        'Wxp/x86': ['xp/x86'],
 
+        'Wnet/x86' : ['2k3/x86'],
         'Wnet/amd64': ['2k3/amd64'],
 
         'Wlh/x86': ['2k8/x86'],
@@ -290,8 +292,9 @@ DRIVER_OS_MAP = {
 
 
     'vioserial': {
-        'Wxp/x86': ['xp/x86', '2k3/x86'],
+        'Wxp/x86': ['xp/x86'],
 
+        'Wnet/x86' : ['2k3/x86'],
         'Wnet/amd64': ['2k3/amd64'],
 
         'Wlh/x86': ['2k8/x86'],

--- a/util/filemap.py
+++ b/util/filemap.py
@@ -196,11 +196,12 @@ DRIVER_OS_MAP = {
 
 
     'NetKVM': {
-        'XP/x86': ['xp/x86', '2k3/x86'],
-        'XP/amd64': ['2k3/amd64'],
+        'Wxp/x86': ['xp/x86', '2k3/x86'],
 
-        'Vista/x86': ['2k8/x86'],
-        'Vista/amd64': ['2k8/amd64'],
+        'Wnet/amd64': ['2k3/amd64'],
+
+        'Wlh/x86': ['2k8/x86'],
+        'Wlh/amd64': ['2k8/amd64'],
 
         'Win7/x86': ['w7/x86'],
         'Win7/amd64': ['2k8R2/amd64', 'w7/amd64'],


### PR DESCRIPTION
NetKVM binary drop paths have been unified with the rest of the
drivers and beginning with the next version (>=127), Vista files
will come from Wlh and XP files from Wxp (32-bit) / Wnet (64-bit).
