### PR TITLE
filemap: Add viohidkmdf.*

### DIFF
--- a/util/filemap.py
+++ b/util/filemap.py
@@ -111,6 +111,8 @@ _vioinputfiles = [
     'vioinput.inf',
     'vioinput.pdb',
     'vioinput.sys',
+    'viohidkmdf.pdb',
+    'viohidkmdf.sys',
 ]
 FILELISTS['vioinput:w7'] = _vioinputfiles + ['WdfCoInstaller01009.dll']
 FILELISTS['vioinput:2k8R2'] = FILELISTS["vioinput:w7"]


### PR DESCRIPTION
As of virtio-win build 132, the vioinput driver consists of two
.pdb and two .sys files. This commit adds viohidkmdf.pdb and
viohidkmdf.sys to the filemap.