### PR TITLE
Drop off Joliet and adjust iso level to 4

### DIFF
--- a/virtio-win.spec
+++ b/virtio-win.spec
@@ -114,7 +114,7 @@ done
 pushd iso-content
 /usr/bin/mkisofs \
     -o ../media/%{name}-%{version}.iso \
-    -r -J \
+    -r -iso-level 4 \
     -input-charset iso8859-1 \
     -V "%{name}-%{version}" .
 popd


### PR DESCRIPTION
The above patch supposed to fix the problem described in
Bug 1782636 - virtio-win iso's volume label is virtio-win-1.9.1
which is not correct

The changes were tested by virtio-win QE team (comment #33),
as well as by v-2-v developers (comments #38 and #39)